### PR TITLE
Exclude README.md from converting

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -42,6 +42,7 @@ kramdown:
 exclude:
   - 'scripts'
   - 'Gemfile'
+  - 'README.md'
 
 downloads:
   vim74w32:


### PR DESCRIPTION
README.mdが_config.ymlでexcludeされていないせいで現状 http://vim-jp.org/README.md にアクセス出来てしまいます。
