### PR TITLE
support jekyll 2.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
 source 'https://rubygems.org'
 
 gem 'github-pages'
-gem 'rouge'

--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@ plugins:     ./_plugins
 
 future:      true
 lsi:         false
-highlighter: rouge
+highlighter: pygments
 markdown:    redcarpet
 permalink:   date
 


### PR DESCRIPTION
github-pages の最新版 22 で発生する警告に対応しました。

Windows用のgithub-pagesをインストール済みのruby
http://files.kaoriya.net/ruby/ruby-2.0.0-p481-i386-mingw32+github-pages-22.zip
においておきます。諸々設定するのが面倒だったら使ってください。

(pygments.rbに、未だにWin対応パッチが入ってないのはなんなんだ…)
