### PR TITLE
remove 'http' for external resources

### DIFF
--- a/_includes/disqus.html
+++ b/_includes/disqus.html
@@ -6,9 +6,9 @@ var disqus_url='{{ site.base-url | escape }}{{ page.url | escape }}';
 var disqus_title='vim-jp &raquo; {{ page.title }}';
 (function() {
   var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-  dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+  dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
   (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
 })();
 </script>
-<noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
-<a href="http://disqus.com" class="dsq-brlink">blog comments powered by <span class="logo-disqus">Disqus</span></a>
+<noscript>Please enable JavaScript to view the <a href="//disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
+<a href="//disqus.com" class="dsq-brlink">blog comments powered by <span class="logo-disqus">Disqus</span></a>

--- a/_includes/hatena.html
+++ b/_includes/hatena.html
@@ -1,1 +1,1 @@
-<a href="http://b.hatena.ne.jp/entry/{{ site.base-url | escape }}{{ hatena-url | escape }}"><img src="http://b.hatena.ne.jp/entry/image/{{ site.base-url | escape }}{{ hatena-url | escape }}" class="hatena-bookmark-icon" alt="Hatena Bookmark"/></a>
+<a href="http://b.hatena.ne.jp/entry/{{ site.base-url | escape }}{{ hatena-url | escape }}"><img src="//b.hatena.ne.jp/entry/image/{{ site.base-url | escape }}{{ hatena-url | escape }}" class="hatena-bookmark-icon" alt="Hatena Bookmark"/></a>

--- a/_includes/sns-badges.html
+++ b/_includes/sns-badges.html
@@ -1,0 +1,5 @@
+<!-- Badges of SNS -->
+<a href="https://twitter.com/share" class="twitter-share-button" data-via="vim_jp" data-lang="ja">ツイート</a>
+<a href="http://b.hatena.ne.jp/entry/{{ site.base-url | escape }}{{ page.url | escape }}" class="hatena-bookmark-button" data-hatena-bookmark-layout="standard" title="このエントリーをはてなブックマークに追加"><img src="//b.st-hatena.com/images/entry-button/button-only.gif" alt="このエントリーをはてなブックマークに追加" /></a>
+<div class="fb-like" data-href="{{ site.base-url }}{{ page.url }}" data-layout="button_count"></div>
+<div class="g-plusone" data-href="{{ site.base-url }}{{ page.url }}" data-size="medium"></div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,11 +10,11 @@
 <link rel="stylesheet" href="/assets/css/table.css" type="text/css" />
 <link rel="stylesheet" href="/assets/css/syntax.css" type="text/css" />
 <link rel="stylesheet" href="/css/default.css" type="text/css" />
-<link rel="alternate" type="application/rss+xml" title="RSS" href="http://vim-jp.org/rss.xml" />
+<link rel="alternate" type="application/rss+xml" title="RSS" href="//vim-jp.org/rss.xml" />
 <link rel="canonical" href="{{ site.base-url }}{{ page.url }}" />
 <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico" />
 <link rel="icon" type="image/x-icon" href="/favicon.ico" />
-<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+<script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
 <script>
 	(function(doc, script) {
 		window.___gcfg = {lang: 'ja'};
@@ -40,8 +40,8 @@
 </script>
 
 <!-- 日本語マニュアル検索用 -->
-<link rel="stylesheet" href="http://www.google.com/cse/style/look/default.css" type="text/css" />
-<script src="http://www.google.com/jsapi" type="text/javascript"></script>
+<link rel="stylesheet" href="//www.google.com/cse/style/look/default.css" type="text/css" />
+<script src="//www.google.com/jsapi" type="text/javascript"></script>
 <script type="text/javascript">
   google.load("search", "1", {language : "ja"});
   google.setOnLoadCallback(function() {
@@ -49,11 +49,11 @@
     var customSearchControl = new google.search.CustomSearchControl("001325159752250591701:65aunpq8rlg");
     customSearchControl.setResultSetSize(google.search.Search.FILTERED_CSE_RESULTSET);
     var options = new google.search.DrawOptions();
-    options.enableSearchboxOnly("http://www.google.com/cse?cx=001325159752250591701:65aunpq8rlg");
+    options.enableSearchboxOnly("//www.google.com/cse?cx=001325159752250591701:65aunpq8rlg");
     customSearchControl.draw('VimdocJaSearch', options);
   }, true);
 
-  $.getJSON("http://vim-jp.herokuapp.com/patches/json?callback=?", function(items) {
+  $.getJSON("//vim-jp.herokuapp.com/patches/json?callback=?", function(items) {
     $.each(items, function() {
       $('<li/>').append(
         $('<a/>').attr({'href': this.link, 'target': '_blank'}).text("Patch " + this.title)
@@ -104,16 +104,16 @@
 						{% endfor %}
 					</ul>
 					</dd>
-					<dt><a href="http://vim-jp.org/vimdoc-ja">日本語マニュアル</a></dt>
+					<dt><a href="//vim-jp.org/vimdoc-ja">日本語マニュアル</a></dt>
 					<dd>
 					<div id="VimdocJaSearch"></div>
 					<div>検索もできます。</div>
 					</dd>
-					<dt><a href="http://github.com/vim-jp/issues/issues">Issues</a></dt>
+					<dt><a href="https://github.com/vim-jp/issues/issues">Issues</a></dt>
 					<dd>日本語で問題報告できるITS(Issue Tracker System)。</dd>
-					<dt><a href="http://vim-jp.org/reading-vimrc">vimrc読書会</a></dt>
+					<dt><a href="//vim-jp.org/reading-vimrc">vimrc読書会</a></dt>
 					<dd>毎週誰かのvimrcを読み合わせします。</dd>
-					<dt><a href="http://vim-jp.org/vim-users-jp">vim-users-jp</a></dt>
+					<dt><a href="//vim-jp.org/vim-users-jp">vim-users-jp</a></dt>
 					<dd>vim-users-jpの過去記事を掲載しています。</dd>
 					<dt><a href="/links.html">リンク集</a></dt>
 					<dd>もっとVimの情報をゲットしよう! <a href="/vimmers2/">Vimmers2</a> (<a href="/vimmers/">旧版</a>)を見てみよう!</dd>
@@ -145,7 +145,7 @@
 
 		<br class="clear" />
 		<div id="footer">
-			<p>Powered by <a href="http://github.com/">github</a>. vim-jp.org is licensed under a <a href="http://creativecommons.org/licenses/by/2.1/jp/">Creative Commons License</a>.
+			<p>Powered by <a href="https://github.com/">github</a>. vim-jp.org is licensed under a <a href="https://creativecommons.org/licenses/by/2.1/jp/">Creative Commons License</a>.
 		</div>
 	</div>
 </body>

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -3,10 +3,7 @@ layout: default
 ---
 <div class="post">
 <h2><a href="{{ post.url }}">{{ page.title }}</a></h2>
-<div class="fb-like" data-href="{{ site.base-url }}{{ page.url }}" data-layout="button_count"></div>
-<div class="g-plusone" data-href="{{ site.base-url }}{{ page.url }}" data-size="medium"></div>
-<a href="https://twitter.com/share" class="twitter-share-button" data-via="vim_jp" data-lang="ja">ツイート</a>
-<a href="http://b.hatena.ne.jp/entry/{{ site.base-url | escape }}{{ page.url | escape }}" class="hatena-bookmark-button" data-hatena-bookmark-layout="standard" title="このエントリーをはてなブックマークに追加"><img src="//b.st-hatena.com/images/entry-button/button-only.gif" alt="このエントリーをはてなブックマークに追加" /></a>
+{% include sns-badges.html %}
 <br />
 {{ content }}
 </div>

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -6,7 +6,7 @@ layout: default
 <div class="fb-like" data-href="{{ site.base-url }}{{ page.url }}" data-layout="button_count"></div>
 <div class="g-plusone" data-href="{{ site.base-url }}{{ page.url }}" data-size="medium"></div>
 <a href="https://twitter.com/share" class="twitter-share-button" data-via="vim_jp" data-lang="ja">ツイート</a>
-<a href="http://b.hatena.ne.jp/entry/{{ site.base-url | escape }}{{ page.url | escape }}" class="hatena-bookmark-button" data-hatena-bookmark-layout="standard" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only.gif" alt="このエントリーをはてなブックマークに追加" /></a>
+<a href="http://b.hatena.ne.jp/entry/{{ site.base-url | escape }}{{ page.url | escape }}" class="hatena-bookmark-button" data-hatena-bookmark-layout="standard" title="このエントリーをはてなブックマークに追加"><img src="//b.st-hatena.com/images/entry-button/button-only.gif" alt="このエントリーをはてなブックマークに追加" /></a>
 <br />
 {{ content }}
 </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -8,7 +8,7 @@ Posted at <span>{{ page.date | date: "%Y/%m/%d" }}</span><br />
 <div class="fb-like" data-href="{{ site.base-url }}{{ page.url }}" data-layout="button_count"></div>
 <div class="g-plusone" data-href="{{ site.base-url }}{{ page.url }}" data-size="medium"></div>
 <a href="https://twitter.com/share" class="twitter-share-button" data-via="vim_jp" data-lang="ja">ツイート</a>
-<a href="http://b.hatena.ne.jp/entry/{{ site.base-url | escape }}{{ page.url | escape }}" class="hatena-bookmark-button" data-hatena-bookmark-layout="standard" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only.gif" alt="このエントリーをはてなブックマークに追加" /></a>
+<a href="http://b.hatena.ne.jp/entry/{{ site.base-url | escape }}{{ page.url | escape }}" class="hatena-bookmark-button" data-hatena-bookmark-layout="standard" title="このエントリーをはてなブックマークに追加"><img src="//b.st-hatena.com/images/entry-button/button-only.gif" alt="このエントリーをはてなブックマークに追加" /></a>
 <br />
 <br />
 {{ content }}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -5,10 +5,7 @@ layout: default
 <div class="post">
 <h2><a href="{{ post.url }}">{{ page.title }}</a></h2>
 Posted at <span>{{ page.date | date: "%Y/%m/%d" }}</span><br />
-<div class="fb-like" data-href="{{ site.base-url }}{{ page.url }}" data-layout="button_count"></div>
-<div class="g-plusone" data-href="{{ site.base-url }}{{ page.url }}" data-size="medium"></div>
-<a href="https://twitter.com/share" class="twitter-share-button" data-via="vim_jp" data-lang="ja">ツイート</a>
-<a href="http://b.hatena.ne.jp/entry/{{ site.base-url | escape }}{{ page.url | escape }}" class="hatena-bookmark-button" data-hatena-bookmark-layout="standard" title="このエントリーをはてなブックマークに追加"><img src="//b.st-hatena.com/images/entry-button/button-only.gif" alt="このエントリーをはてなブックマークに追加" /></a>
+{% include sns-badges.html %}
 <br />
 <br />
 {{ content }}

--- a/_layouts/tips.html
+++ b/_layouts/tips.html
@@ -3,10 +3,7 @@ layout: default
 ---
 <div class="post">
 <h2><a href="{{ post.url }}">{{ page.title }}</a></h2>
-<div class="fb-like" data-href="{{ site.base-url }}{{ page.url }}" data-layout="button_count"></div>
-<div class="g-plusone" data-href="{{ site.base-url }}{{ page.url }}" data-size="medium"></div>
-<a href="https://twitter.com/share" class="twitter-share-button" data-via="vim_jp" data-lang="ja">ツイート</a>
-<a href="http://b.hatena.ne.jp/entry/{{ site.base-url | escape }}{{ page.url | escape }}" class="hatena-bookmark-button" data-hatena-bookmark-layout="standard" title="このエントリーをはてなブックマークに追加"><img src="//b.st-hatena.com/images/entry-button/button-only.gif" alt="このエントリーをはてなブックマークに追加" /></a>
+{% include sns-badges.html %}
 <br />
 {{ content }}
 </div>

--- a/_layouts/tips.html
+++ b/_layouts/tips.html
@@ -6,7 +6,7 @@ layout: default
 <div class="fb-like" data-href="{{ site.base-url }}{{ page.url }}" data-layout="button_count"></div>
 <div class="g-plusone" data-href="{{ site.base-url }}{{ page.url }}" data-size="medium"></div>
 <a href="https://twitter.com/share" class="twitter-share-button" data-via="vim_jp" data-lang="ja">ツイート</a>
-<a href="http://b.hatena.ne.jp/entry/{{ site.base-url | escape }}{{ page.url | escape }}" class="hatena-bookmark-button" data-hatena-bookmark-layout="standard" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only.gif" alt="このエントリーをはてなブックマークに追加" /></a>
+<a href="http://b.hatena.ne.jp/entry/{{ site.base-url | escape }}{{ page.url | escape }}" class="hatena-bookmark-button" data-hatena-bookmark-layout="standard" title="このエントリーをはてなブックマークに追加"><img src="//b.st-hatena.com/images/entry-button/button-only.gif" alt="このエントリーをはてなブックマークに追加" /></a>
 <br />
 {{ content }}
 </div>

--- a/_layouts/vimmers.html
+++ b/_layouts/vimmers.html
@@ -7,12 +7,12 @@
 <title>vim-jp &raquo; {{ page.title }}</title>
 <link rel="stylesheet" href="/assets/css/site.css" type="text/css" />
 <link rel="stylesheet" href="/assets/css/vimmers.css" type="text/css" />
-<link rel="alternate" type="application/rss+xml" title="RSS" href="http://vim-jp.org/rss.xml" />
+<link rel="alternate" type="application/rss+xml" title="RSS" href="//vim-jp.org/rss.xml" />
 <link rel="canonical" href="{{ site.base-url }}{{ page.url }}" />
 <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico" />
 <link rel="icon" type="image/x-icon" href="/favicon.ico" />
 <script type="text/javascript" src="https://apis.google.com/js/plusone.js"></script>
-<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+<script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
 </head>
 <body>
 
@@ -40,7 +40,7 @@
 		</div>
 		<br class="clear" />
 		<div id="footer">
-			<p>Powered by <a href="http://github.com/">github</a>. vim-jp.org is licensed under a <a href="http://creativecommons.org/licenses/by/2.1/jp/">Creative Commons License</a>.
+			<p>Powered by <a href="https://github.com/">github</a>. vim-jp.org is licensed under a <a href="https://creativecommons.org/licenses/by/2.1/jp/">Creative Commons License</a>.
 		</div>
 	</div>
 </body>

--- a/_layouts/vimmers2.html
+++ b/_layouts/vimmers2.html
@@ -9,13 +9,13 @@
 
     <title>vim-jp &raquo; {{ page.title }}</title>
 
-    <link rel="alternate" type="application/rss+xml" title="RSS" href="http://vim-jp.org/rss.xml">
+    <link rel="alternate" type="application/rss+xml" title="RSS" href="//vim-jp.org/rss.xml">
     <link rel="canonical" href="{{ site.base-url }}{{ page.url }}">
     <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
 
-    <link rel="stylesheet" href="http://necolas.github.com/normalize.css/3.0.1/normalize.css">
-    <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Lato:100,400">
+    <link rel="stylesheet" href="//necolas.github.com/normalize.css/3.0.1/normalize.css">
+    <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Lato:100,400">
     <link rel="stylesheet" href="/assets/css/vimmers2.css" type="text/css">
 
     <script src="/assets/javascripts/modernizr-svg.js"></script>

--- a/index.html
+++ b/index.html
@@ -13,10 +13,7 @@ title: Vimのユーザーと開発者を結ぶコミュニティサイト
 <p>vim-jp はテキストエディタ Vim と日本・日本語に関わるあらゆるリソースを集約することを目的としたコミュニティです。</p>
 <p>Vim と vim-jp についての詳細は<a href="/about.html">コチラ</a>をご覧ください。</p>
 
-<div class="fb-like" data-href="{{ site.base-url }}/" data-layout="button_count"></div>
-<div class="g-plusone" data-href="{{ site.base-url }}/" data-size="medium"></div>
-<a href="https://twitter.com/share" class="twitter-share-button" data-via="vim_jp" data-lang="ja">ツイート</a>
-<a href="http://b.hatena.ne.jp/entry/{{ site.base-url | escape }}" class="hatena-bookmark-button" data-hatena-bookmark-layout="standard" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only.gif" alt="このエントリーをはてなブックマークに追加" /></a>
+{% include sns-badges.html %}
 
 <ul class="entry-list2">
 


### PR DESCRIPTION
HTTPS対応のための準備 (releated #188) です。
また一部の外部サービスのリンク先URLを https へ書き換えています。
(例: <https://github.com>)

あと幾つか気になる場所があったので直す予定。