### PR TITLE
fix tools

### DIFF
--- a/.local.vimrc
+++ b/.local.vimrc
@@ -8,10 +8,10 @@ function! s:new_entry()
   if len(title) == 0
     return
   endif
-  exec "e" printf("%s/_posts/%s-%s.md", s:basedir, strftime("%Y-%m-%d"), substitute(title, '\s', '-', 'g'))
+  exec "e" printf("%s/_posts/blog/%s-%s.md", s:basedir, strftime("%Y-%m-%d"), substitute(title, '\s', '-', 'g'))
   call setline(1, [
   \ '---',
-  \ 'layout: post',
+  \ 'layout: blog',
   \ 'category: blog',
   \ 'title: ' . title,
   \ '---',

--- a/scripts/release.rb
+++ b/scripts/release.rb
@@ -13,7 +13,7 @@ if !ARGV.empty? and rel = conf[ARGV[0]]
   open("#{root}/#{file}", "wb") {|f|
     f.puts <<"EOS"
 ---
-layout: post
+layout: release
 category: release
 title: #{rel['title']} #{rel['version']} リリース
 


### PR DESCRIPTION
posts を生成する系のスクリプトを、layout の変更に対応。
.local.vim に関しては出力先の修正(_posts から _posts/blog へ)もついでに実施した。

fixed #204