### PR TITLE
Build on CircleCI for preview

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'github-pages', '>= 89'
+gem 'github-pages', '>= 93'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-vim-jp.github.io [![Build Status](https://travis-ci.org/vim-jp/vim-jp.github.io.svg)](https://travis-ci.org/vim-jp/vim-jp.github.io)
-=================
+# vim-jp.github.io
+
+[![CircleCI](https://circleci.com/gh/vim-jp/vim-jp.github.io.svg?style=svg)](https://circleci.com/gh/vim-jp/vim-jp.github.io)
+[![Build Status](https://travis-ci.org/vim-jp/vim-jp.github.io.svg)](https://travis-ci.org/vim-jp/vim-jp.github.io)
 
   * [EditSite](https://github.com/vim-jp/vim-jp.github.io/wiki/EditSite) サイト編集の手順 (ローカル環境での確認方法)

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,11 @@
+general:
+  artifacts:
+    - "_site"
+
+test:
+  pre:
+    - bundle show
+  override:
+    - bundle exec jekyll build
+  post:
+    - find _site -type f

--- a/circle.yml
+++ b/circle.yml
@@ -1,11 +1,7 @@
-general:
-  artifacts:
-    - "_site"
-
 test:
   pre:
     - bundle show
   override:
-    - bundle exec jekyll build
+    - bundle exec jekyll build -d $CIRCLE_ARTIFACTS
   post:
-    - find _site -type f
+    - find $CIRCLE_ARTIFACTS -type f


### PR DESCRIPTION
CircleCI 上で [ビルド](https://circleci.com/gh/vim-jp/vim-jp.github.io) するようにします。
メリットとしてはビルドしたものを [Web で プレビュー](https://4-2390405-gh.circle-artifacts.com/0//tmp/circle-artifacts.etBqqO4/index.html) できることです。
将来 PR などで修正点を確認するのに有利に働くでしょう。

現在は basepath とか細かい調整をしてないので CSS や 各リンクは辿れず、
コンテンツ以外のプレビューはできません。そのあたりは追々やっていければ良いなと。

詳細は [CircleCI のドキュメント](https://circleci.com/docs/build-artifacts/) も参照してください。
以下の様なわかりやすいURLも生成されているので、それを活用できたらなと。

    https://circleci.com/api/v1/project/:org/:repo/:build_num/artifacts/:container-index/path/to/artifact