### PR TITLE
docs: Update build instructions

### DIFF
--- a/docs/build_linux.md
+++ b/docs/build_linux.md
@@ -33,7 +33,7 @@ Ubuntu 14.04 LTSを使った場合のビルド方法を説明します。
 
         $ sudo apt-get install lua5.2 liblua5.2-dev
 
-    LuaJITのLua拡張を使うには以下も追加で必要です。
+    LuaJITのLua拡張を使うには代わりに以下も追加で必要です。
 
         $ sudo apt-get install luajit libluajit-5.1
 
@@ -77,7 +77,7 @@ Ubuntu 14.04 LTSを使った場合のビルド方法を説明します。
           --enable-fail-if-missing
         $ make
 
-    もしLuaインタプリタとしてLuaJITを利用したい場合は以下の様に指定します。(上記に加えて`--with-luajit`を指定している点に注意)
+    もしLuaインタプリタとしてLuaJITを利用したい場合は以下の様に`--with-luajit`を追加します。
 
         $ ./configure --with-features=huge --enable-gui=gtk2
           --enable-perlinterp --enable-pythoninterp

--- a/docs/build_linux.md
+++ b/docs/build_linux.md
@@ -18,11 +18,12 @@ Ubuntu 14.04 LTSを使った場合のビルド方法を説明します。
 
     ※実際は1行
 
-    GVim (GTK2-GNOME GUI版)をビルドするには以下も追加で必要です。 Unity 版の Ubuntu を利用する場合は、GNOME GUI よりも GTK2 GUI の方が推奨されます。
+    gvim (GTK2 GUI版)をビルドするには以下も追加で必要です。(GUI版は一般的にはGTK2またはGTK3を使うのがよいでしょう。)
 
-        $ sudo apt-get install libxmu-dev libgnomeui-dev libxpm-dev
+        $ sudo apt-get install libxmu-dev libgtk2.0-dev libxpm-dev
 
-    ※GTK2 GUI版の場合は`libgnomeui-dev`の代わりに、`libgtk2.0-dev`を指定。
+    ※GTK3 GUI版の場合は`libgtk2.0-dev`の代わりに、`libgtk-3-dev`を指定。<br />
+    ※GTK2-GNOME GUI版の場合は`libgtk2.0-dev`の代わりに、`libgnomeui-dev`を指定。<br />
 
     Perl, Python2,3, Ruby拡張を使うには以下も追加で必要です。
 
@@ -48,11 +49,6 @@ Ubuntu 14.04 LTSを使った場合のビルド方法を説明します。
 
     `git clone`を実行した後にソースが更新された場合は、以下のコマンドで最新のソースを取得できます。
 
-        $ git fetch
-        $ git merge
-
-    ローカルでの変更がない場合、あるいは2つをまとめて以下のコマンドでもOKです。
-
         $ git pull
 
     特定のバージョンを指定して取得する場合は、以下のコマンドを実行します。
@@ -63,17 +59,18 @@ Ubuntu 14.04 LTSを使った場合のビルド方法を説明します。
 
     `vim/src`フォルダに移動し以下のコマンドを実行します。
 
-        $ ./configure --with-features=huge --enable-gui=gnome2
+        $ ./configure --with-features=huge --enable-gui=gtk2
           --enable-fail-if-missing
         $ make
 
-    ※`./configure`の行は実際は1行  
-    ※GTK2 GUI版の場合は`--enable-gui=gnome2`の代わりに、`--enable-gui=gtk2`を指定  
-    ※`--enable-fail-if-missing`は足りないパッケージがある場合にエラーとするためのオプション  
+    ※`./configure`の行は実際は1行<br />
+    ※GTK3 GUI版の場合は`--enable-gui=gtk2`の代わりに、`--enable-gui=gtk3`を指定<br />
+    ※GTK2-GNOME GUI版の場合は`--enable-gui=gtk2`の代わりに、`--enable-gui=gnome2`を指定<br />
+    ※`--enable-fail-if-missing`は足りないパッケージがある場合にエラーとするためのオプション<br />
 
     もしPerl拡張やRuby拡張、Python拡張を使う場合は以下の様に指定します。
 
-        $ ./configure --with-features=huge --enable-gui=gnome2
+        $ ./configure --with-features=huge --enable-gui=gtk2
           --enable-perlinterp --enable-pythoninterp
           --enable-python3interp --enable-rubyinterp
           --enable-fail-if-missing
@@ -81,7 +78,7 @@ Ubuntu 14.04 LTSを使った場合のビルド方法を説明します。
 
     もしLua拡張を合わせて有効化する場合は以下の様に指定します。
 
-        $ ./configure --with-features=huge --enable-gui=gnome2
+        $ ./configure --with-features=huge --enable-gui=gtk2
           --enable-perlinterp --enable-pythoninterp
           --enable-python3interp --enable-rubyinterp
           --enable-luainterp
@@ -90,7 +87,7 @@ Ubuntu 14.04 LTSを使った場合のビルド方法を説明します。
 
     もしLuaインタプリタとしてLuaJITを利用したい場合は以下の様に指定します。(上記に加えて`--with-luajit`を指定している点に注意)
 
-        $ ./configure --with-features=huge --enable-gui=gnome2
+        $ ./configure --with-features=huge --enable-gui=gtk2
           --enable-perlinterp --enable-pythoninterp
           --enable-python3interp --enable-rubyinterp
           --enable-luainterp --with-luajit

--- a/docs/build_linux.md
+++ b/docs/build_linux.md
@@ -68,15 +68,7 @@ Ubuntu 14.04 LTSを使った場合のビルド方法を説明します。
     ※GTK2-GNOME GUI版の場合は`--enable-gui=gtk2`の代わりに、`--enable-gui=gnome2`を指定<br />
     ※`--enable-fail-if-missing`は足りないパッケージがある場合にエラーとするためのオプション<br />
 
-    もしPerl拡張やRuby拡張、Python拡張を使う場合は以下の様に指定します。
-
-        $ ./configure --with-features=huge --enable-gui=gtk2
-          --enable-perlinterp --enable-pythoninterp
-          --enable-python3interp --enable-rubyinterp
-          --enable-fail-if-missing
-        $ make
-
-    もしLua拡張を合わせて有効化する場合は以下の様に指定します。
+    もしPerl拡張やPython2/3拡張、Ruby拡張、Lua拡張を使う場合は以下の様に指定します。
 
         $ ./configure --with-features=huge --enable-gui=gtk2
           --enable-perlinterp --enable-pythoninterp

--- a/docs/build_windows_mingw.md
+++ b/docs/build_windows_mingw.md
@@ -15,16 +15,16 @@ title: MinGWを使ってのビルド方法
 
         pacman -Suuy
 
-    MSYS2を終了して再実行するように言われた場合は、それに従ってminttyのウィンドウを閉じ、スタートメニューから `MSYS2 MSYS` を実行し、再度 `pacman -Suuy` を実行します。
+    MSYS2を終了して再実行するように言われた場合は、それに従ってminttyのウィンドウを閉じ、スタートメニューから再度 `MSYS2 MSYS` を実行し、`pacman -Suu` を実行します。
     システムの更新が終わったら、以下のコマンドを実行してGitやGCCなど必要なパッケージをインストールします。
 
         pacman -S git mingw-w64-i686-toolchain mingw-w64-x86_64-toolchain
 
     pacmanのwrapperコマンドであるpacboyを使えば、もう少し簡単に、以下のコマンドでインストールできます。
 
-        pacboy -S git: toolchain:m
+        pacboy -S git toolchain:m
 
-    pacboyの使い方は、当該コマンドを引数無しで実行すると表示されます。`:`でプレフィックス無し、`:x`で64bit用(`mingw-w64-x86_64-`)、`:i`で32bit用(`mingw-w64-i686-`)、`:m`で64/32bit用両方がインストールされます。
+    pacboyの使い方は、`pacboy help`を実行すると表示されます。パッケージ名の後に`:x`で64bit用(`mingw-w64-x86_64-`)、`:i`で32bit用(`mingw-w64-i686-`)、`:m`で64/32bit用両方がインストールされます。
 
 3.  ソース取得
 

--- a/docs/build_windows_mingw.md
+++ b/docs/build_windows_mingw.md
@@ -20,6 +20,12 @@ title: MinGWを使ってのビルド方法
 
         pacman -S git mingw-w64-i686-toolchain mingw-w64-x86_64-toolchain
 
+    pacmanのwrapperコマンドであるpacboyを使えば、もう少し簡単に、以下のコマンドでインストールできます。
+
+        pacboy -S git: toolchain:m
+
+    pacboyの使い方は、当該コマンドを引数無しで実行すると表示されます。`:`でプレフィックス無し、`:x`で64bit用(`mingw-w64-x86_64-`)、`:i`で32bit用(`mingw-w64-i686-`)、`:m`で64/32bit用両方がインストールされます。
+
 3.  ソース取得
 
     ビルドするターゲットに合わせて、スタートメニューから `MSYS2 MinGW 64-bit` または `MSYS2 MinGW 32-bit` のいずれかを実行し、そこから以下を実行します。

--- a/docs/build_windows_mingw.md
+++ b/docs/build_windows_mingw.md
@@ -3,26 +3,30 @@ layout: docs
 title: MinGWを使ってのビルド方法
 ---
 
+ビルド手順はVimのバージョンによって一部変更されていることがあります。公式のビルド手順は、ソースファイル内の [src/INSTALLpc.txt](https://github.com/vim/vim/blob/master/src/INSTALLpc.txt) および、[MinGW用Makefile](https://github.com/vim/vim/blob/master/src/Make_ming.mak)や[Cygwin/MinGW共通Makefile](https://github.com/vim/vim/blob/master/src/Make_cyg_ming.mak)内のコメントを参照してください。
+
 1.  msys2 のインストール
 
-    以前は Windows 上の gcc コンパイラをインストールする為に [MinGW \| Minimalist GNU for Windows](http://www.mingw.org/) をダウンロードしましたが、最近は <a href="https://msys2.github.io/">msys2</a> を使うのが一般的です。以下は msys2 がインストール済みでかつ gcc コンパイラが動作する前提で記述しています。
+    以前は Windows 上の gcc コンパイラをインストールする為に [MinGW \| Minimalist GNU for Windows](http://www.mingw.org/) をダウンロードしましたが、最近は <a href="https://msys2.github.io/">msys2</a> を使うのが一般的です。以下は msys2 がインストール済みの前提で記述しています。
 
-2.  Gitのインストール
+2.  GitやGCCのインストール
 
-    [Git](https://git-scm.com/)からGitをインストールします。
+    スタートメニューから `MSYS2 MSYS` を実行し、以下のコマンドを実行してシステムの更新を行います。
+
+        pacman -Suuy
+
+    MSYS2を終了して再実行するように言われた場合は、それに従ってminttyのウィンドウを閉じ、スタートメニューから `MSYS2 MSYS` を実行し、再度 `pacman -Suuy` を実行します。
+    システムの更新が終わったら、以下のコマンドを実行してGitやGCCなど必要なパッケージをインストールします。
+
+        pacman -S git mingw-w64-i686-toolchain mingw-w64-x86_64-toolchain
 
 3.  ソース取得
 
-    コマンドプロンプトから以下を実行します。
+    ビルドするターゲットに合わせて、スタートメニューから `MSYS2 MinGW 64-bit` または `MSYS2 MinGW 32-bit` のいずれかを実行し、そこから以下を実行します。
 
         git clone https://github.com/vim/vim.git
 
     `git clone`を実行した後にソースが更新された場合は、以下のコマンドで最新のソースを取得できます。
-
-        git fetch
-        git merge
-
-    ローカルでの変更がない場合、あるいは2つをまとめて以下のコマンドでもOKです。
 
         git pull
 
@@ -34,52 +38,40 @@ title: MinGWを使ってのビルド方法
 
     `vim/src`フォルダに移動し以下のコマンドを実行します。
 
-        mingw32-make -f Make_ming.mak GUI=yes IME=yes MBYTE=yes ^
+        mingw32-make -f Make_ming.mak GUI=yes IME=yes MBYTE=yes \
           ICONV=yes DEBUG=no
 
-    もしPerl拡張やRuby拡張、Python拡張を使う場合は以下の様に指定します。
+    もしPerl拡張やRuby拡張、Python2/3拡張を使う場合は以下の様に指定します。
 
-        mingw32-make -f Make_ming.mak GUI=yes IME=yes MBYTE=yes ICONV=yes ^
-          PERL=C:\strawberry\perl DYNAMIC_PERL=yes PERL_VER=512 ^
-          PYTHON=c:\python27 DYNAMIC_PYTHON=yes PYTHON_VER=27 ^
-          RUBY=c:\ruby193 DYNAMIC_RUBY=yes RUBY_VER=19 ^
-          RUBY_VER_LONG=1.9.1 CSCOPE=yes NETBEANS=yes ^
-          ARCH=x86-64 STATIC_STDCPLUS=yes DEBUG=no
+        mingw32-make -f Make_ming.mak GUI=yes IME=yes MBYTE=yes ICONV=yes \
+          PERL=c:/strawberry/perl DYNAMIC_PERL=yes PERL_VER=526 \
+          PYTHON=c:/python27 DYNAMIC_PYTHON=yes PYTHON_VER=27 \
+          PYTHON3=c:/python36 DYNAMIC_PYTHON3=yes PYTHON3_VER=36 \
+          RUBY=c:/Ruby24 DYNAMIC_RUBY=yes RUBY_VER=24 RUBY_API_VER_LONG=2.4.0 \
+          CSCOPE=yes NETBEANS=yes STATIC_STDCPLUS=yes DEBUG=no
 
-    msys2 付属の perl/python/ruby を使ってビルドする場合は以下の様に指定します。
+    msys2 付属の perl/python/ruby を使う場合は以下の様に指定します。
 
-        mingw32-make -f Make_ming.mak GUI=yes IME=yes MBYTE=yes ICONV=yes ^
-          PERL=c:/msys64/mingw64 DYNAMIC_PERL=yes PERL_VER=522 ^
-            PERLEXE=c:/msys64/mingw64/bin/perl.exe ^
-            PERLLIB=c:/msys64/mingw64/lib/perl5/core_perl ^
-          PYTHON=c:/msys64/mingw64 DYNAMIC_PYTHON=yes PYTHON_VER=27 ^
-            PYTHON_HOME=c:/msys64/mingw64 ^
-            PYTHONINC=-Ic:/msys64/mingw64/include/python2.7 ^
-            DYNAMIC_PYTHON_DLL=libpython2.7.dll ^
-          RUBY=c:/msys64/mingw64 DYNAMIC_RUBY=yes RUBY_VER=22 RUBY_VER_LONG=2.2.0 ^
-          CSCOPE=yes NETBEANS=yes ARCH=x86-64 STATIC_STDCPLUS=yes DEBUG=no
+        mingw32-make -f Make_ming.mak GUI=yes IME=yes MBYTE=yes ICONV=yes \
+          PERL=c:/msys64/mingw64 DYNAMIC_PERL=yes PERL_VER=522 \
+            PERLEXE=c:/msys64/mingw64/bin/perl.exe \
+            PERLLIB=c:/msys64/mingw64/lib/perl5/core_perl \
+          PYTHON=c:/msys64/mingw64 DYNAMIC_PYTHON=yes PYTHON_VER=27 \
+            PYTHON_HOME=c:/msys64/mingw64 \
+            PYTHONINC=-Ic:/msys64/mingw64/include/python2.7 \
+            DYNAMIC_PYTHON_DLL=libpython2.7.dll \
+          PYTHON3=c:/msys64/mingw64 DYNAMIC_PYTHON3=yes PYTHON3_VER=36 \
+            PYTHON3_HOME=c:/msys64/mingw64/ \
+            PYTHON3INC=-Ic:/msys64/mingw64/include/python3.6m \
+            DYNAMIC_PYTHON3_DLL=libpython3.6m.dll \
+          RUBY=c:/msys64/mingw64 DYNAMIC_RUBY=yes RUBY_VER=24 RUBY_API_VER_LONG=2.4.0 \
+          CSCOPE=yes NETBEANS=yes STATIC_STDCPLUS=yes DEBUG=no
 
-    Python3 も足したいのであれば
+    注意1) 複数行に跨るのでシェルスクリプトに記載して実行して下さい。
 
-        mingw32-make -f Make_ming.mak GUI=yes IME=yes MBYTE=yes ICONV=yes ^
-          PERL=c:/msys64/mingw64 DYNAMIC_PERL=yes PERL_VER=522 ^
-            PERLEXE=c:/msys64/mingw64/bin/perl.exe ^
-            PERLLIB=c:/msys64/mingw64/lib/perl5/core_perl ^
-          PYTHON=c:/msys64/mingw64 DYNAMIC_PYTHON=yes PYTHON_VER=27 ^
-            PYTHON_HOME=c:/msys64/mingw64 ^
-            PYTHONINC=-Ic:/msys64/mingw64/include/python2.7 ^
-            DYNAMIC_PYTHON_DLL=libpython2.7.dll ^
-          PYTHON3=c:/msys64/mingw64 DYNAMIC_PYTHON3=yes PYTHON3_VER=35 ^
-            PYTHON3_HOME=c:/msys64/mingw64/ ^
-            PYTHON3INC=-Ic:/msys64/mingw64/include/python3.5m ^
-            DYNAMIC_PYTHON3_DLL=libpython3.5m.dll ^
-          RUBY=c:/msys64/mingw64 DYNAMIC_RUBY=yes RUBY_VER=22 RUBY_VER_LONG=2.2.0 ^
-          CSCOPE=yes NETBEANS=yes ARCH=x86-64 STATIC_STDCPLUS=yes DEBUG=no
+    注意2) Vimのバージョンによっては、`ARCH=x86-64` (64bit) または `ARCH=i686` (32bit) を指定しなければならない場合があります。
 
-    注意1) 複数行に跨るのでバッチファイルに記載して実行して下さい。
+    注意3) ターゲットが32bitの場合は、`c:/msys64/mingw64` を `c:/msys64/mingw32` に置き換えてください。
 
-    注意2) ARCH は i686 または x86-64 を指定して下さい。
-
-    Vim 7.4.393以降で使えるようになったDirectWriteを有効にするには、MinGWの派生版である[MinGW-w64](http://mingw-w64.sourceforge.net/)を使ってコンパイルする必要があります。
-    32bit版は `DIRECTX=yes ARCH=i686`、64bit版は `DIRECTX=yes ARCH=x86-64` を指定する必要があります。
-    なお、DirectWriteを有効にすると、デフォルトでは実行時に libstdc++-6.dll, libgcc\_s\_sjlj-1.dll が必要となりますが、`STATIC_STDCPLUS=yes` を指定することでこれらのライブラリをスタティックリンクすることが出来ます。
+    Vim 7.4.393以降で使えるようになったDirectWriteを有効にするには、`DIRECTX=yes` を指定する必要があります。
+    なお、DirectWriteを有効にすると、デフォルトでは実行時に libstdc++-6.dll, libgcc\_s\_sjlj-1.dll 等が必要となりますが、`STATIC_STDCPLUS=yes` を指定することでこれらのライブラリをスタティックリンクすることが出来ます。(VimやGCCのバージョンによって出来ないこともあり。)

--- a/docs/build_windows_mingw.md
+++ b/docs/build_windows_mingw.md
@@ -41,16 +41,17 @@ title: MinGWを使ってのビルド方法
         mingw32-make -f Make_ming.mak GUI=yes IME=yes MBYTE=yes \
           ICONV=yes DEBUG=no
 
-    もしPerl拡張やRuby拡張、Python2/3拡張を使う場合は以下の様に指定します。
+    もしPerl拡張やPython2/3拡張、Ruby拡張、Lua拡張を使う場合は以下の様に指定します。
 
         mingw32-make -f Make_ming.mak GUI=yes IME=yes MBYTE=yes ICONV=yes \
           PERL=c:/strawberry/perl DYNAMIC_PERL=yes PERL_VER=526 \
           PYTHON=c:/python27 DYNAMIC_PYTHON=yes PYTHON_VER=27 \
           PYTHON3=c:/python36 DYNAMIC_PYTHON3=yes PYTHON3_VER=36 \
           RUBY=c:/Ruby24 DYNAMIC_RUBY=yes RUBY_VER=24 RUBY_API_VER_LONG=2.4.0 \
+          LUA=c:/lua53 DYNAMIC_LUA=yes LUA_VER=53 \
           CSCOPE=yes NETBEANS=yes STATIC_STDCPLUS=yes DEBUG=no
 
-    msys2 付属の perl/python/ruby を使う場合は以下の様に指定します。
+    msys2 付属の perl/python/ruby/lua を使う場合は以下の様に指定します。
 
         mingw32-make -f Make_ming.mak GUI=yes IME=yes MBYTE=yes ICONV=yes \
           PERL=c:/msys64/mingw64 DYNAMIC_PERL=yes PERL_VER=522 \
@@ -65,6 +66,7 @@ title: MinGWを使ってのビルド方法
             PYTHON3INC=-Ic:/msys64/mingw64/include/python3.6m \
             DYNAMIC_PYTHON3_DLL=libpython3.6m.dll \
           RUBY=c:/msys64/mingw64 DYNAMIC_RUBY=yes RUBY_VER=24 RUBY_API_VER_LONG=2.4.0 \
+          LUA=c:/msys64/mingw64 DYNAMIC_LUA=yes LUA_VER=53 \
           CSCOPE=yes NETBEANS=yes STATIC_STDCPLUS=yes DEBUG=no
 
     注意1) 複数行に跨るのでシェルスクリプトに記載して実行して下さい。

--- a/docs/build_windows_msvc.md
+++ b/docs/build_windows_msvc.md
@@ -1,9 +1,11 @@
 ---
 layout: docs
-title: VisualStudio10を使ってのビルド方法
+title: VisualStudioを使ってのビルド方法
 ---
 
-VisualStudio10が既にインストールされている前提で説明します。
+ビルド手順はVimのバージョンによって一部変更されていることがあります。公式のビルド手順は、ソースファイル内の [src/INSTALLpc.txt](https://github.com/vim/vim/blob/master/src/INSTALLpc.txt) および、[VC用Makefile](https://github.com/vim/vim/blob/master/src/Make_mvc.mak)内のコメントを参照してください。
+
+ここではVisualStudio(2010以降)が既にインストールされている前提で説明します。
 
 1.  Gitのインストール
 
@@ -17,11 +19,6 @@ VisualStudio10が既にインストールされている前提で説明します
 
     `git clone`を実行した後にソースが更新された場合は、以下のコマンドで最新のソースを取得できます。
 
-        git fetch
-        git merge
-
-    ローカルでの変更がない場合、あるいは2つをまとめて以下のコマンドでもOKです。
-
         git pull
 
     特定のバージョンを指定して取得する場合は、以下のコマンドを実行します。
@@ -30,27 +27,30 @@ VisualStudio10が既にインストールされている前提で説明します
 
 3.  コンパイル
 
+    必要に応じてビルド前に`vcvarsall.bat`や`vcvars32.bat`等を実行して、VCを動かすための環境変数をセットアップして下さい。`vim/src`フォルダ内にある`msvc****.bat`が使える場合もあります。
+
     `vim/src`フォルダに移動し以下のコマンドを実行します。
 
-        nmake -f Make_mvc.mak GUI=yes IME=yes MBYTE=yes
+        nmake -f Make_mvc.mak GUI=yes IME=yes MBYTE=yes ^
           ICONV=yes DEBUG=no
 
-    ※実際は1行
+    もしPerl拡張やPython2/3拡張などを使う場合は以下の様に指定します。
 
-    もしPerl拡張やRuby拡張、Python拡張を使う場合は以下の様に指定します。
+        nmake -f Make_mvc.mak GUI=yes IME=yes MBYTE=yes ICONV=yes ^
+          PERL=C:\strawberry\perl DYNAMIC_PERL=yes PERL_VER=526 ^
+          PYTHON=c:\python27 DYNAMIC_PYTHON=yes PYTHON_VER=27 ^
+          PYTHON3=c:\python36 DYNAMIC_PYTHON3=yes PYTHON3_VER=36 ^
+          CSCOPE=yes NETBEANS=yes DEBUG=no
 
-        nmake -f Make_mvc.mak GUI=yes IME=yes MBYTE=yes
-          ICONV=yes PERL=C:\strawberry\perl DYNAMIC_PERL=yes
-          PERL_VER=512 PYTHON=c:\python27 DYNAMIC_PYTHON=yes
-          PYTHON_VER=27 RUBY=c:\ruby193 DYNAMIC_RUBY=yes RUBY_VER=19
-          RUBY_VER_LONG=1.9.1 CSCOPE=yes MSVCVER=6.0 NETBEANS=yes
-          DEBUG=no
+    注意) 複数行に跨るのでバッチファイルに記載して実行して下さい。(行末の `^` は行継続を示しています。)
 
-    ※実際は1行  
-    必要に応じてビルド前に`vcvarsall.bat`や`vcvars32.bat`等を実行しておいて下さい。
+    Ruby拡張を使うには、少々面倒な手順が必要になります。通常はRubyとVimを同じコンパイラでビルドする必要があるのですが、現在Windowsで広く使われている[RubyInstaller](https://rubyinstaller.org/)はMinGWでビルドされているので、そのままではVCから使うことができないのです。
+    詳細は、[src/INSTALLpc.txt](https://github.com/vim/vim/blob/master/src/INSTALLpc.txt)の "Building with Ruby support" の項を参照してください。
 
-    VC11以降を使う場合は、`SDK_INCLUDE_DIR` で `Win32.mak` があるディレクトリを指定する必要があります。例:
+    Vim 7.4.393以降で使えるようになったDirectWriteを有効にするには、`DIRECTX=yes` を指定する必要があります。
+
+    VC2012以降を使う場合は、`SDK_INCLUDE_DIR` で `Win32.mak` があるフォルダを指定しなければならない場合があります。例:
 
         "SDK_INCLUDE_DIR=C:\Program Files (x86)\Microsoft SDKs\Windows\v7.1A\Include"
 
-    Vim 7.4.393以降で使えるようになったDirectWriteを有効にするには、`DIRECTX=yes` を指定する必要があります。
+    `SDK_INCLUDE_DIR` の指定が必要かどうかは、Vimのバージョンに依存します。

--- a/docs/build_windows_msvc.md
+++ b/docs/build_windows_msvc.md
@@ -52,6 +52,6 @@ title: VisualStudioを使ってのビルド方法
 
     VC2012以降を使う場合は、`SDK_INCLUDE_DIR` で `Win32.mak` があるフォルダを指定しなければならない場合があります。例:
 
-        "SDK_INCLUDE_DIR=C:\Program Files (x86)\Microsoft SDKs\Windows\v7.1A\Include"
+        nmake -f Make_mvc.mak "SDK_INCLUDE_DIR=C:\Program Files (x86)\Microsoft SDKs\Windows\v7.1A\Include" ...
 
     `SDK_INCLUDE_DIR` の指定が必要かどうかは、Vimのバージョンに依存します。

--- a/docs/build_windows_msvc.md
+++ b/docs/build_windows_msvc.md
@@ -34,17 +34,18 @@ title: VisualStudioを使ってのビルド方法
         nmake -f Make_mvc.mak GUI=yes IME=yes MBYTE=yes ^
           ICONV=yes DEBUG=no
 
-    もしPerl拡張やPython2/3拡張などを使う場合は以下の様に指定します。
+    もしPerl拡張やPython2/3拡張、Lua拡張などを使う場合は以下の様に指定します。
 
         nmake -f Make_mvc.mak GUI=yes IME=yes MBYTE=yes ICONV=yes ^
           PERL=C:\strawberry\perl DYNAMIC_PERL=yes PERL_VER=526 ^
           PYTHON=c:\python27 DYNAMIC_PYTHON=yes PYTHON_VER=27 ^
           PYTHON3=c:\python36 DYNAMIC_PYTHON3=yes PYTHON3_VER=36 ^
+          LUA=c:\lua53 DYNAMIC_LUA=yes LUA_VER=53 ^
           CSCOPE=yes NETBEANS=yes DEBUG=no
 
     注意) 複数行に跨るのでバッチファイルに記載して実行して下さい。(行末の `^` は行継続を示しています。)
 
-    Ruby拡張を使うには、少々面倒な手順が必要になります。通常はRubyとVimを同じコンパイラでビルドする必要があるのですが、現在Windowsで広く使われている[RubyInstaller](https://rubyinstaller.org/)はMinGWでビルドされているので、そのままではVCから使うことができないのです。
+    Ruby拡張を使うには少々面倒な手順が必要になるため、ここでは説明を割愛します。通常はRubyとVimを同じコンパイラでビルドする必要があるのですが、現在Windowsで広く使われている[RubyInstaller](https://rubyinstaller.org/)はMinGWでビルドされているので、そのままではVCから使うことができないためです。
     詳細は、[src/INSTALLpc.txt](https://github.com/vim/vim/blob/master/src/INSTALLpc.txt)の "Building with Ruby support" の項を参照してください。
 
     Vim 7.4.393以降で使えるようになったDirectWriteを有効にするには、`DIRECTX=yes` を指定する必要があります。


### PR DESCRIPTION
Windows向けビルド手順がだいぶ古くなってきた感があるので、大幅書き換えしてみました。

* 公式のビルド手順書である src/INSTALLpc.txt 等へのリンクを追加。
* 最新のVimのソースに合わせて記述を更新。
  - SDK_INCLUDE_DIR, RUBY_API_VER_LONG, ARCH 等。 (Closes #216)
  - VC版は、if_rubyに関する設定例を削除し、INSTALLpc.txt を参照するように修正。(手順が複雑なため)
* git fetch & git merge は、mercurial の頃からの記述の名残なので、削除して git pull のみに変更。
* if_xxx のバージョンを現時点での最新のものに変更。
  注: Perl は、Strawberry Perl と MSYS2 付属のものでバージョンに差異あり。
* MinGW版は、MSYS2 を使った記述に全面変更。
* Luaを有効にする設定を追記。