### PR TITLE
Update CI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
           key: vim-jp-{{ .Branch }}-{{ checksum "Gemfile" }}
       - run:
           name: Install Ruby dependencies
-          command: bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs=4 --retry=3 && bundle clean
+          command: bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs=4 --retry=3 && bundle clean -V
       - save_cache:
           key: vim-jp-{{ .Branch }}-{{ checksum "Gemfile" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,12 +7,15 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: vim-jp-{{ .Branch }}-{{ checksum "Gemfile" }}
+          keys:
+            - vim-jp-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile" }}
+            - vim-jp-{{ arch }}-{{ .Branch }}
+            - vim-jp-
       - run:
           name: Install Ruby dependencies
           command: bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs=4 --retry=3 && bundle clean -V
       - save_cache:
-          key: vim-jp-{{ .Branch }}-{{ checksum "Gemfile" }}
+          key: vim-jp-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile" }}
           paths:
             - vendor/bundle
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/ruby:2.3.3
+      - image: circleci/ruby:2.4
     working_directory: ~/vim-jp
     steps:
       - checkout
@@ -10,7 +10,7 @@ jobs:
           key: vim-jp-{{ .Branch }}-{{ checksum "Gemfile" }}
       - run:
           name: Install Ruby dependencies
-          command: bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs=4 --retry=3
+          command: bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs=4 --retry=3 && bundle clean
       - save_cache:
           key: vim-jp-{{ .Branch }}-{{ checksum "Gemfile" }}
           paths:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 rvm:
   # RubyInstallerで提供される最新版を、指定・利用の目安としている
-  - 2.2.4
+  - 2.4.2
 before_script: "bundle show"
 script: "bundle exec jekyll build"
 after_script: "find _site -type f"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+# TODO: 今後しばらくは travis-ci を使わないので近い将来消す
+
 language: ruby
 rvm:
   # RubyInstallerで提供される最新版を、指定・利用の目安としている

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'github-pages', '>= 93'
+gem 'github-pages', '>= 166'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # vim-jp.github.io
 
 [![CircleCI](https://circleci.com/gh/vim-jp/vim-jp.github.io.svg?style=svg)](https://circleci.com/gh/vim-jp/vim-jp.github.io)
-[![Build Status](https://travis-ci.org/vim-jp/vim-jp.github.io.svg)](https://travis-ci.org/vim-jp/vim-jp.github.io)
 
   * [EditSite](https://github.com/vim-jp/vim-jp.github.io/wiki/EditSite) サイト編集の手順 (ローカル環境での確認方法)


### PR DESCRIPTION
* travis-ci を無効化
    * 一応 rubyのバージョンは上げた
    * 将来的に消す、とコメントに書いた
    * badge を削除
* CircleCIの設定を見直し
    * ruby 2.4の最新を使うように設定
    * キャッシュ戦略(=キーの選択)を変更。[CircleCIのドキュメント](https://circleci.com/docs/2.0/caching/)に合わせる形へ
    * キャッシュ内の使ってないgemsを消すために `bundle install` の後に `bundle clean` を実行
*   その他プロジェクトの設定
    * eyecatch.io の設定を削除した。なんかサービス終わってそう :disappointed: 
    * travis-ci の設定を disable した
    