### PR TITLE
Write entry: "Vim 8.1 released!"

### DIFF
--- a/_posts/blog/2018-05-18-Vim-8.1-released.md
+++ b/_posts/blog/2018-05-18-Vim-8.1-released.md
@@ -1,0 +1,161 @@
+---
+layout: blog
+category: blog
+title: Vim 8.1 released!
+---
+
+Vim 8.1 がリリースされました。
+
+以下勝手訳。
+<!-- 新機能の解説は[こちら](TODO)。 -->
+
+----------------------------------------------------------------------
+
+[Vim 8.1 released!](https://groups.google.com/d/msg/vim_announce/K1lBxTJb73Y/xVnQDQSsAgAJ)
+
+Hello Vim users!
+
+
+告知:  Vim (Vi IMproved) version 8.1
+
+
+沢山の小さな改善とバグフィックスを含んだマイナーリリースです。主な新機能は端末ウ
+ィンドウです。Web サイト上にいくつかスクリーンショットを置きました。
+https://www.vim.org/vim-8.1-released.php
+
+Vim 8.1 をインストールしたら Vim 8.1 の変更の詳細はこちらで見れます:
+        :help version8.1
+もしくはオンライン上でも:
+https://raw.githubusercontent.com/vim/vim/master/runtime/doc/version8.txt
+
+
+
+感謝の気持ちはこちらへ
+----------------------
+
+もし Vim を気に入ってくれたなら、ウガンダ南部の貧しい子供たちを助けてあげてください: <http://iccf-holland.org>
+
+
+入手方法
+--------
+
+最新の Vim を入手するには Git を使うのがおすすめです。 要約:
+
+    git clone https://github.com/vim/vim.git
+
+詳しい情報はこちら: <https://www.vim.org/git.php>
+
+MS-Windows 用のインストーラが用意されています:
+
+<https://ftp.nluug.nl/pub/vim/pc/gvim81.exe>
+
+どのシステムでどのファイルをダウンロードすればいいかはこちらを見てください:
+
+<https://www.vim.org/download.php>
+
+ミラーサイトの一覧はこちら:
+<https://www.vim.org/mirrors.php>
+
+
+ダウンロード可能なファイル:
+
+UNIX:
+
+sources + runtime files, bzip2 compressed:
+
+<https://ftp.nluug.nl/pub/vim/unix/vim-8.1.tar.bz2>
+
+その他:
+
+HTML に変換されたヘルプファイル:
+
+<https://ftp.nluug.nl/pub/vim/doc/vim81html.zip>
+
+MS-WINDOWS 全部入り:
+
+セルフインストーラ。すべてのランタイムファイルを含む。ダイナミックロード版:
+
+<https://ftp.nluug.nl/pub/vim/pc/gvim81.exe>
+
+MS-WINDOWS 個別ファイル:
+
+ランタイムファイル:
+
+<https://ftp.nluug.nl/pub/vim/pc/vim81rt.zip>
+
+Windows 95/98/NT/2000/XP/7 の GUI バイナリ:
+
+<https://ftp.nluug.nl/pub/vim/pc/gvim81.zip>
+
+OLE サポート付きの GUI バイナリ:
+
+<https://ftp.nluug.nl/pub/vim/pc/gvim81ole.zip>
+
+Windows NT/2000/XP/7 のコンソール版:
+
+<https://ftp.nluug.nl/pub/vim/pc/vim81w32.zip>
+
+PC 用ソース (CR-LF改行):
+
+<https://ftp.nluug.nl/pub/vim/pc/vim81src.zip>
+
+デバッグ用:
+
+<https://ftp.nluug.nl/pub/vim/pc/gvim81.pdb>
+
+<https://ftp.nluug.nl/pub/vim/pc/gvim81ole.pdb>
+
+<https://ftp.nluug.nl/pub/vim/pc/vim81w32.pdb>
+
+AMIGA:
+
+ランタイムとソースのみ提供で、バイナリはなし:
+
+<https://ftp.nluug.nl/pub/vim/amiga/vim81rt.tgz>
+
+<https://ftp.nluug.nl/pub/vim/amiga/vim81src.tgz>
+
+
+このバージョンでは以下のものは省略されました:
+
+- The 16-bit DOS, OS/2 and Amiga versions, these are obsolete.
+- The 32-bit console version for MS-DOS/Windows 95/98
+- The 16 bit MS-Windows version
+
+
+メーリングリスト
+----------------
+
+Vim ユーザーの方は、なにか質問があったら Vim メーリングリストを調べてみてください。
+たくさんのチップスやスクリプトや解決法が見つかるでしょう。
+Vim についての質問をすることもできます。ただし、登録が必要です。
+<https://www.vim.org/maillist.php#vim> を見てください。
+
+Vim の開発を手伝ってくれる方は、vim-dev メーリングリストに登録すると、
+新しい機能について議論したり、あたらしいパッチを入手したりできます。
+<https://www.vim.org/maillist.php#vim-dev> を見てください。
+
+話題を限定したメーリングリスト:
+
+Macintosh 関連:  <https://www.vim.org/maillist.php#vim-mac>
+
+質問をする前にアーカイブを検索してください。誰かが既に答えているかもしれません。
+
+
+バグレポート
+------------
+
+バグレポートは <vim-dev@vim.org> に送ってください。
+問題をはっきり正確に説明してくださるようお願いします。
+メールの返答に費やす時間は Vim を改善する時間から消費されています! 
+必ず、再現可能な手順を示し、そのバグに関連する設定や環境依存のものがないか確認してみてください。
+あなたの vimrc を使わずに Vim を起動してみてください: "vim -u NONE"。
+可能なら他のマシンで試してみてください。":help bugs" を読んでください。
+そしてもし可能ならパッチを送ってください!
+
+あるいは、github で issue や pull request を作成してください。
+問題が再現し、修正されたら通るテストを書いてみてください。
+<https://github.com/vim/vim> を見てください。
+
+
+Happy Vimming!


### PR DESCRIPTION
このメールの翻訳です。
https://groups.google.com/d/msg/vim_announce/K1lBxTJb73Y/xVnQDQSsAgAJ

文面はほぼ [Vim 8.0 リリース時の記事](https://vim-jp.org/blog/2016/09/13/Vim-8.0-released.html)と一緒です。
ただ URL が https に変わったり置き場所自体が変わったりしてました。