### PR TITLE
Add license link to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@
 [![CircleCI](https://circleci.com/gh/vim-jp/vim-jp.github.io.svg?style=svg)](https://circleci.com/gh/vim-jp/vim-jp.github.io)
 
   * [EditSite](https://github.com/vim-jp/vim-jp.github.io/wiki/EditSite) サイト編集の手順 (ローカル環境での確認方法)
+
+<a rel="license" href="http://creativecommons.org/licenses/by/2.1/jp/"><img alt="クリエイティブ・コモンズ・ライセンス" style="border-width:0" src="https://i.creativecommons.org/l/by/2.1/jp/88x31.png" /></a><br />この 作品 は <a rel="license" href="http://creativecommons.org/licenses/by/2.1/jp/">クリエイティブ・コモンズ 表示 2.1 日本 ライセンス</a>の下に提供されています。

--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@
 
   * [EditSite](https://github.com/vim-jp/vim-jp.github.io/wiki/EditSite) サイト編集の手順 (ローカル環境での確認方法)
 
-<a rel="license" href="http://creativecommons.org/licenses/by/2.1/jp/"><img alt="クリエイティブ・コモンズ・ライセンス" style="border-width:0" src="https://i.creativecommons.org/l/by/2.1/jp/88x31.png" /></a><br />この 作品 は <a rel="license" href="http://creativecommons.org/licenses/by/2.1/jp/">クリエイティブ・コモンズ 表示 2.1 日本 ライセンス</a>の下に提供されています。
+<a rel="license" href="http://creativecommons.org/licenses/by/2.1/jp/"><img alt="クリエイティブ・コモンズ・ライセンス" style="border-width:0" src="https://i.creativecommons.org/l/by/2.1/jp/88x31.png" /></a><br />この作品は <a rel="license" href="http://creativecommons.org/licenses/by/2.1/jp/">クリエイティブ・コモンズ 表示 2.1 日本 ライセンス</a>の下に提供されています。


### PR DESCRIPTION
vim-jp.github.io is licensed under CC-BY 2.1 JP, but it only displayed in the footer of the web page.


https://github.com/vim-jp/vim-jp.github.io/blob/ec2aa8aee604292a8d6b8281e2a29d793c5583c1/_layouts/default.html#L131


I think it is not useful to find the license.
So this change adds the license to the README.


By the way, I think it is better if we add a LICENSE file that contains the full text of the license. But I'm not sure how to get the full text as plain text. We can confirm the license from https://creativecommons.org/licenses/by/2.1/jp/legalcode, but it is an HTML.
So I just add it to README.