### PR TITLE
Fix drop links

### DIFF
--- a/links.html
+++ b/links.html
@@ -24,14 +24,10 @@ title: リンク集
 
 <h2>Vim 情報提供サイト</h2>
 <dl>
-    <dt><a href="http://vimwiki.net/">VimWiki</a></dt>
-    <dd>匿名掲示板2ちゃんねるから収集されたVimのTipsなど。</dd>
     <dt><a href="http://lingr.com/room/vim">Lingr vim-jp</a></dt>
     <dd>チャットルーム。</dd>
     <dt><a href="http://qiita.com/tags/Vim">Qiita</a></dt>
     <dd>QiitaのVimに関する投稿</dd>
-    <dt><a href="https://plus.google.com/communities/105049811056605918816">Vim - Google+</a></dt>
-    <dd>Google+上のVimコミュニティ(英語)</dd>
     <dt><a href="http://nanasi.jp/">名無しのvim使いへようこそ。 &mdash; 名無しのvim使い</a></dt>
     <dd>Vimの基本から応用までの情報まとめ</dd>
     <dt><a href="http://vimawesome.com/">Vim Awesome</a></dt>


### PR DESCRIPTION
VimWiki がドメイン失効して他のサイトになっていた模様なので削除しました。
同様に Google+ もクローズされているので削除しました。