### PR TITLE
Change MacVim binary to macvim-dev/macvim

### DIFF
--- a/_data/downloads.yml
+++ b/_data/downloads.yml
@@ -1,12 +1,6 @@
 vim-win: &vim-win
   title: Windows 32ビット/64ビット
   version: '8.2 latest'
-vim-mac: &vim-mac
-  title: OS X 10.9+
-  version: '8.0.1633'
-  info: +macvim-kaoriya, 14MB DMG
-  url: http://vim-jp.org/redirects/splhack/macvim-kaoriya/latest/
-
 vim-w32: &vim-w32
   <<: *vim-win
   title: Windows 32ビット
@@ -17,6 +11,12 @@ vim-w64: &vim-w64
   title: Windows 64ビット
   info: vim-win32-installer, 17.2MB ZIP
   url: https://vim-jp.org/redirects/vim/vim-win32-installer/latest/x64/
+
+vim-mac: &vim-mac
+  title: macOS 10.9+
+  version: '8.2.319'
+  info: macvim, 16.6MB DMG
+  url: http://vim-jp.org/redirects/macvim-dev/macvim/latest/
 
 list:
   - *vim-w32


### PR DESCRIPTION
MacVim のダウンロードリンクを https://github.com/macvim-dev/macvim の MacVim に切り替えたい。