### PR TITLE
Adjust the position of facebook button

### DIFF
--- a/_includes/sns-badges.html
+++ b/_includes/sns-badges.html
@@ -2,6 +2,6 @@
 <div class="sns-badges">
   <a class="twitter-share-button" href="https://twitter.com/share" data-via="vim_jp" data-lang="ja">ツイート</a>
   <a class="hatena-bookmark-button" href="http://b.hatena.ne.jp/entry/{{ site.base-url | escape }}{{ page.url | escape }}" data-hatena-bookmark-layout="standard" title="このエントリーをはてなブックマークに追加"><img src="//b.st-hatena.com/images/entry-button/button-only.gif" alt="このエントリーをはてなブックマークに追加" /></a>
-  <div class="fb-like" data-href="{{ site.base-url }}{{ page.url }}" data-layout="button_count"></div>
+  <div class="fb-like" data-href="{{ site.base-url }}{{ page.url }}" data-layout="button_count" style="height: 20px"></div>
   <div class="g-plusone" data-href="{{ site.base-url }}{{ page.url }}" data-size="medium"></div>
 </div>


### PR DESCRIPTION
## 修正の内容

トップページ https://vim-jp.org などに設置されている Facebook のいいねボタンの位置が他のボタンと比べて縦方向にずれてしまっているのを修正してみました。他に良い方法が思いつかなかったので、対応する div タグに style を直指定するという行儀の悪い方法をとっています… 何か他に良い方法があったら教えていただけると嬉しいです。

## スクリーンショット

### before
<img width="250" alt="before" src="https://user-images.githubusercontent.com/64692680/113740909-1caf1400-973c-11eb-9cde-02b3c7cb9e42.png">

### after
<img width="250" alt="after" src="https://user-images.githubusercontent.com/64692680/113740898-19b42380-973c-11eb-8848-6ed95050b763.png">
