### PR TITLE
docs: Revise How to Write Patches

### DIFF
--- a/docs/how_to_write_patches.md
+++ b/docs/how_to_write_patches.md
@@ -14,7 +14,7 @@ Vimはバージョン管理ツールとして Git を採用しているおかげ
 ## 準備
 
 まず前提条件として、あなたのPCではコンパイル環境が整備されており、[Git](https://git-scm.com/)が使える状態になっているとします。
-Linuxユーザーであれば[Linuxでのビルド方法](http://vim-jp.org/docs/build_windows_msvc.html)を、Windowsユーザーであれば[Visual Studioでのコンパイル方法](http://vim-jp.org/docs/build_windows_msvc.html)もしくは[MinGWでのコンパイル方法](http://vim-jp.org/docs/build_windows_mingw.html)も参照して下さい。
+Linuxユーザーであれば[Linuxでのビルド方法](http://vim-jp.org/docs/build_linux.md)を、Windowsユーザーであれば[Visual Studioでのコンパイル方法](http://vim-jp.org/docs/build_windows_msvc.html)もしくは[MinGWでのコンパイル方法](http://vim-jp.org/docs/build_windows_mingw.html)も参照して下さい。
 
 最新のソースコードを取得する為に、シェル(Windowsであればコマンドプロンプト)から以下を実行します。
 

--- a/docs/how_to_write_patches.md
+++ b/docs/how_to_write_patches.md
@@ -11,16 +11,22 @@ Vimはバージョン管理ツールとして Git を採用しているおかげ
 最近、www.vim.org のページに[Vim development](http://www.vim.org/develop.php)という記事ができました。
 こちらは英語ですが、手順がよくまとまっているため、英語を苦にしない人はこちらを参照するとよいでしょう。
 
+## 準備
+
 まず前提条件として、あなたのPCではコンパイル環境が整備されており、[Git](https://git-scm.com/)が使える状態になっているとします。
-Windowsユーザーであれば[Visual Studioでのコンパイル方法](http://vim-jp.org/docs/build_windows_msvc.html)もしくは[MinGWでのコンパイル方法](http://vim-jp.org/docs/build_windows_mingw.html)も参照して下さい。
+Linuxユーザーであれば[Linuxでのビルド方法](http://vim-jp.org/docs/build_windows_msvc.html)を、Windowsユーザーであれば[Visual Studioでのコンパイル方法](http://vim-jp.org/docs/build_windows_msvc.html)もしくは[MinGWでのコンパイル方法](http://vim-jp.org/docs/build_windows_mingw.html)も参照して下さい。
 
 最新のソースコードを取得する為に、シェル(Windowsであればコマンドプロンプト)から以下を実行します。
 
-    $ git clone https://github.com/vim/vim
+    $ git clone https://github.com/vim/vim.git
 
-次に修正内容に対応するブランチを作成します。
+## 修正
 
-    $ git checkout -b add-new-func-trim
+修正内容に対応するブランチを作成します。
+
+    $ git switch -c add-new-func-trim
+
+(git のバージョンが古い場合は `switch -c` の代わりに `checkout -b` を使います。)
 
 ブランチを移動したらソースファイルを修正します。
 
@@ -32,7 +38,7 @@ Windowsユーザーであれば[Visual Studioでのコンパイル方法](http:/
 
 すでに用意されているパッチをソースファイルに適用するなら、以下のようなコマンドを実行します。
 
-    $ patch -p1 < something.patch
+    $ git apply something.patch
 
 ソースファイルを修正したらコミットしましょう。
 
@@ -40,37 +46,81 @@ Windowsユーザーであれば[Visual Studioでのコンパイル方法](http:/
 
 もし、修正中に元のソースコードが変更された場合は、次のコマンドでリポジトリを同期させます。
 
-    $ git fetch --all
+    $ git fetch origin master:master
     $ git rebase master
+
+## テスト
+
+コードを修正したならテストも書きましょう。不具合修正であれば、同じ不具合を再発させないためにもテストは重要です。テストの書き方は以下を参照してください。
+
+- [`:help testing`](http://vim-jp.org/vimdoc-ja/testing.html#testing)
+- [src/testing/README.txt](https://github.com/vim/vim/blob/master/src/testing/README.txt)
+
+### テストの実行方法
+
+テストを実行するにはいくつかのやり方がありますが、`src/testing/` ディレクトリ内で make を実行するのが良いでしょう。
+
+Unix 系の場合:
+
+    全テストを実行
+    $ make
+
+    特定のファイルのテストを実行
+    $ make test_channel
+
+    特定のファイルの特定名称のテストを実行 (部分一致)
+    $ make test_channel TEST_FILTER=Test_communicate
+
+    GUI で実行
+    $ make GUI_FLAG=-g
+
+Windows の場合 (MSVC):
+
+    全テストを実行
+    $ nmake -f Make_dos.mak
+
+    特定のファイルのテストを実行
+    $ nmake -f Make_dos.mak test_channel
+
+    特定のファイルの特定名称のテストを実行 (部分一致)
+    $ nmake -f Make_dos.mak test_channel TEST_FILTER=Test_communicate
+
+    GUI で実行
+    $ nmake -f Make_dos.mak VIMPROG=..\gvim
+
+## 送信
 
 全ての修正が完了したら pull-request を送信しましょう。GitHub 上で vim のリポジトリから Fork ボタンをクリックするか、[hub](https://github.com/github/hub) コマンドをお持ちであれば `hub fork` でも可能です。fork が出来たら自分のリポジトリに対して push します。
 
     $ hub fork
-    $ git push [ユーザーID] add-new-func-trim
+    $ git push [ユーザーID] HEAD -u
 
-あとはブラウザで vim のリポジトリを開くと pull-request ボタンが表示されるので指示に従って pull-request を作成して下さい。その際、海外の方も開発に参加していますので本文は英語で書いて頂く必要があります。
+push すると以下のような表示が出ます。
+
+    remote:
+    remote: Create a pull request for '[ブランチ名]' on GitHub by visiting:
+    remote:      https://github.com/[ユーザーID]/vim/pull/new/[ブランチ名]
+    remote:
+
+
+表示された URL をブラウザで開くと pull-request の作成画面が出るので指示に従って pull-request を作成して下さい。その際、海外の方も開発に参加していますので本文は英語で書いて頂く必要があります。
 
 pull-request の冒頭で
 
 - 発生している現象
 - 再現手順
 
-を説明します。また、パッチを作成してメーリングリストに送信する方法もあります。
-
-    $ git diff master > add-new-func-trim.diff
-
-これで作成したパッチの差分ファイルが作成出来るので、メーリングリスト[vim\_dev](https://groups.google.com/forum/#!forum/vim_dev)に添付ファイルを付けるか本文に貼り付けてメールを投げます。(vim\_dev初回投稿時はBram氏の承認が必要なため、すぐには表示されません。)
-pull-request と同様にメールの冒頭で
-
-- 発生している現象
-- 再現手順
-
 を説明します。
+
+パッチを作成してメーリングリスト[vim\_dev](https://groups.google.com/forum/#!forum/vim_dev)に送信する方法もありますが、CI が流れないので推奨はしません。(vim\_dev初回投稿時はBram氏の承認が必要です。投稿が表示されないからと何度も同じ投稿をしないように注意してください。)
+
 あとは誰かがレビューしてくれるはずです。パッチを投げる前に、vim-jpの[Issues](http://github.com/vim-jp/issues/issues)で相談すると、歴戦の強者達がアドバイスを送ってくれることでしょう。
 なおパッチファイルにはパッチ作成者の名前が記されますが、基本的には実名が相応しいと以前Bram氏が言っていました。
 
+## マージ
+
 レビューが完了しBram氏からのOKが出たら、あとはパッチが取り込まれたVimがリリースされるまで待ちます。
-いつパッチが取り込まれるかは不定期なので分かりません。すぐに取り込まれる場合もありますし、[todo.txt](https://github.com/vim/vim/blob/master/runtime/doc/todo.txt)に追加されて数ヶ月あるいは数年待たされる場合もあります。ひたすら待ちましょう。
+いつパッチが取り込まれるかは不定期なので分かりません。すぐに取り込まれる場合もありますし、[todo.txt](https://github.com/vim/vim/blob/master/runtime/doc/todo.txt)に追加されて数ヶ月あるいは数年待たされる場合もあります。(必要性をアピールしたり)パッチをメンテナンスしつつ、ひたすら待ちましょう。
 Vimでは基本的にバグ修正が優先して取り込まれ、新機能の追加は後回しにされる傾向が強いです。
 特に巨大な変更の場合、パッチの取り込みがマイナーリリース時点まで保留されることもあります。
 
@@ -83,6 +133,6 @@ Vimでは基本的にバグ修正が優先して取り込まれ、新機能の�
 
 さぁ君もCONTRIBUTE AUTHORになろう！
 
-参考資料：
+## 参考資料
 
 - [Vim development](http://www.vim.org/develop.php)


### PR DESCRIPTION
* 見出しを追加
* Linuxでのビルド方法へのリンクを追加
* コマンドを見直し
  - git clone の URL に .git を追加
    ビルド方法のページに合わせた
  - git checkout -b => git switch -c
  - patch -p1 => git apply
  - git fetch のやり方
    master ブランチをチェックアウトせずに最新に更新
  - git push のやり方
    HEAD を指定することでブランチ名の指定を省略
    修正後の再 push をやりやすいように `-u` を追加
* テストの書き方、実行方法を追加
* PR の作成方法を、push 時の URL にアクセスする方法に変更
* メーリングリストへの送付を非推奨に
* マージ待ちの間にパッチのメンテナンスをすることを追記