### PR TITLE
Show scrollbar in pre tag

### DIFF
--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -63,7 +63,6 @@ li > p {
 
 pre {
   font-family: monospace;
-  font-size: 1.4em;
   overflow: auto;
 }
 

--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -63,6 +63,7 @@ li > p {
 
 pre {
   font-family: monospace;
+  font-size: 1.1em;
   overflow: auto;
 }
 

--- a/assets/css/syntax.css
+++ b/assets/css/syntax.css
@@ -8,7 +8,7 @@
 	border: 1px solid #dedede; /* gray */
 	font-family: Monaco, "Courier New", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", monospace;
 	margin-bottom: 1em;
-	overflow: hidden;
+	overflow: auto;
 	padding: .5em;
 	background-color: #eaeaea;
 }


### PR DESCRIPTION
From vim-jp's slack

```
Ken Takata  12:09 PM
コードブロック内に文字が収まらない場合、スクロールバーを出したい。
...
Ken Takata  12:28 PM
フォントサイズはここか。1.4em はちょっとでかすぎませんかね。1.2くらいでいいのでは？
```

Screenshot

<img width="399" alt="スクリーンショット 2021-05-30 20 57 55" src="https://user-images.githubusercontent.com/56591/120103323-05176900-c18a-11eb-84e3-7bd34bd63718.png">
