### PR TITLE
replace Google CSE with own form

### DIFF
--- a/_includes/search-vimdoc_ja.html
+++ b/_includes/search-vimdoc_ja.html
@@ -1,0 +1,6 @@
+<form action="https://www.google.com/search" method="get" class="search-vimdoc_ja" noreferrer>
+  <input name="q" type="text" />
+  <input name="q" type="hidden" value="site:https://vim-jp.org/vimdoc-ja/"/>
+  <input name="udm" type="hidden" value="14" />
+  <button>検索</button>
+</form>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -22,9 +22,6 @@
 <!-- SNSボタンの読み込み -->
 <script src="/assets/javascripts/social-network-buttons.js" async></script>
 
-<!-- 日本語マニュアル検索ボックス -->
-<script src="https://www.google.com/jsapi"></script>
-
 <!-- パッチリスト読み込み -->
 <script src="/assets/javascripts/patch-list.js" async></script>
 
@@ -75,21 +72,7 @@
 					</dd>
 					<dt><a href="//vim-jp.org/vimdoc-ja">日本語マニュアル</a></dt>
 					<dd>
-
-					<!-- Google CSE -->
-					<script>
-					  (function() {
-					    var cx = '001325159752250591701:65aunpq8rlg';
-					    var gcse = document.createElement('script');
-					    gcse.type = 'text/javascript';
-					    gcse.async = true;
-					    gcse.src = 'https://cse.google.com/cse.js?cx=' + cx;
-					    var s = document.getElementsByTagName('script')[0];
-					    s.parentNode.insertBefore(gcse, s);
-					  })();
-					</script>
-					<gcse:search id="VimdocJaSearch"></gcse:search>
-
+					{% include search-vimdoc_ja.html %}
 					<div>検索もできます。</div>
 					</dd>
 					<dt><a href="https://github.com/vim-jp/issues/issues">Issues</a></dt>


### PR DESCRIPTION
Google CSE を独自の form で置き換える実験

![image_360](https://github.com/user-attachments/assets/26a69e38-1dfd-40fe-99e9-e13624ec1018)

以下のブラウザではほぼ問題なく機能しているっぽい

* Chrome
* Edge
* Firefox

ChromeとEdgeでは一度検索した後に、
戻るボタンでページを戻って検索語を変更してから再検索すると、
1度目の検索結果が表示されるという問題を見つけた。
この時、リロードすると検索結果は更新される。
この問題はFirefoxでは再現しないのでChromiumエンジンの問題だと推測される。
キャッシュがミスヒットする何かがChromiumにはあるのかも。

もうちょいデザイン(CSS)を周りに馴染ませたいのと、
前述のバグの正体がわかったらマージしても良いかな。


