### PR TITLE
fix: Slack の招待ページリンクをダウンロードボタンにして目立つように

### DIFF
--- a/docs/chat.md
+++ b/docs/chat.md
@@ -19,7 +19,7 @@ vim-jp Slack コミュニティでは以下のリンク先に記する行動規�
 
 ## 参加方法
 
-[行動規範に同意して招待ページへ移動する](https://join.slack.com/t/vim-jp/shared_invite/zt-2zvpj2pbl-Pb_k0owijQ8HuZtQSbtFww)
+<a href="https://join.slack.com/t/vim-jp/shared_invite/zt-2zvpj2pbl-Pb_k0owijQ8HuZtQSbtFww"><button class="download_button">行動規範に同意して招待ページへ移動する</button></a>
 
 Slack の仕様によりリンク切れが起きる場合があります。その場合はお手数ですが [GitHub の issue で連絡](https://github.com/vim-jp/vim-jp.github.io/issues/new?title=Slack%E6%8B%9B%E5%BE%85%E3%83%AA%E3%83%B3%E3%82%AF%E5%88%87%E3%82%8C&labels=contents)して頂けますようお願い致します。
 


### PR DESCRIPTION
## 概要
以前、どなたかが、知り合いをSlackに招待しようとして、招待ページではなく、vim-jp.slack.com のリンクを踏んで、ログインの画面に遷移してしまうことがあった。
導線をわかりやすくするために、ボタン化し、デザインとしてサイドバーにあるダウンロードボタンと同じものを使用した。

## 議論
- ダウンロードボタンと同じ見た目でいいか
- (同じ見た目でいい場合)クラスを使いまわしでいいか

## スクリーンショット
<img width="2293" height="1317" alt="image" src="https://github.com/user-attachments/assets/26637f68-3dad-4e00-8355-fbd2f42330d9" />
