### PR TITLE
add a guidance of vim-jp Slack on top description

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@ title: Vimのユーザーと開発者を結ぶコミュニティサイト
 <img class="entry-logo" src="/assets/images/vim2-128.png" alt="Image of vim-jp" />
 <p>vim-jp はテキストエディタ Vim と日本・日本語に関わるあらゆるリソースを集約することを目的としたコミュニティです。</p>
 <p>Vim と vim-jp についての詳細は<a href="/about.html">コチラ</a>をご覧ください。</p>
+<p>現在の vim-jp では主に Slack にて参加者間のコミュニケーションが活発に行われています。その Slack に参加するには<a href="/docs/chat.html">コチラ</a>をご覧ください</p>
 
 {% include sns-badges.html %}
 


### PR DESCRIPTION
vim-jp Slackへの動線が分かりづらいという意見を頂いたので、トップエリアに動線を追加します。