### PR TITLE
Remove twitter's deprecated embedded search timeline

### DIFF
--- a/_includes/twitter-widget.html
+++ b/_includes/twitter-widget.html
@@ -1,2 +1,0 @@
-<!-- Twitter widget -->
-<a class="twitter-timeline" data-dnt="true" href="https://twitter.com/search?q=vim%20lang%3Aja%20-RT%20-from%3Avim" data-widget-id="303310203405877250">Vim に関するツイート</a>

--- a/index.html
+++ b/index.html
@@ -47,6 +47,4 @@ title: Vimのユーザーと開発者を結ぶコミュニティサイト
 
 <br />
 
-{% include twitter-widget.html %}
-
 </div>


### PR DESCRIPTION
X/Twitterの検索タイムライン widget の提供が終了しており、consoleにその旨の警告が出ていたのに加え、「Vim に関するツイート」という無意味な表示を消すための変更です。

参考: [Deprecating widget settings](https://devcommunity.x.com/t/deprecating-widget-settings/102295)