### PR TITLE
Build and deploy Pages with actions …

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,0 +1,46 @@
+name: Build and deploy GitHub Pages
+
+on:
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Build
+        uses: actions/jekyll-build-pages@v1
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          retention-days: 7
+
+  deploy:
+
+    needs: build
+
+    runs-on: ubuntu-24.04
+
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+
+    # Deploy to the github-pages environment
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    if: github.ref == 'refs/heads/master'
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Actionsに添付されるArtifactsを使ってPRの内容をプレビューできるようにします。
そのために暗黙で実行されていたJekyllのビルドを、Actionsで実行するように変更します。

ビルドの出力ファイルはArtifactsへ "github-pages.zip" としてアップロードします。
この時、Artifactsは7日間だけ保存します。
またこの "github-pages.zip" はダウンロードして
[koron/pages-preview](https://github.com/koron/pages-preview) を使うことで
手軽にローカルプレビューできるようになります。

赤枠で囲ったやつが "github-pages.zip" です。
<img width="1045" height="835" alt="image" src="https://github.com/user-attachments/assets/bab0b7c7-88d1-4801-906a-4b39127b418e" />

最後にmasterブランチへの変更の場合だけ、GitHub Pagesへのデプロイを実施します。