### PR TITLE
fix(css): update google search height

### DIFF
--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -213,7 +213,7 @@ div.links > div > h2 {
 
 #VimdocJaSearch {
   display: block;
-  height: 28px;
+  height: 68px;
 }
 #VimdocJaSearch .gsc-control-cse {
   margin: 0;


### PR DESCRIPTION
## 概要
- Google CSE の検索フォームの高さがいつの間にか大きくなっていたため、文字が被らない様に追従

### 修正前
<img width="353" height="160" alt="image" src="https://github.com/user-attachments/assets/7f04f7ea-c540-4a46-abcb-b23b9bbea94f" />

### 修正後
<img width="370" height="208" alt="image" src="https://github.com/user-attachments/assets/ecdb9d99-67c6-49c1-8cf7-340d27e66de5" />